### PR TITLE
ci: release on main merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,10 @@
 name: Release
 
 on:
-  workflow_dispatch: # manually
-    inputs:
-      dry_run:
-        description: Skip publishing
-        required: false
-        default: true
-        type: boolean
+  push:
+    branches:
+      - main
+      
 jobs:
   release:
     name: Release
@@ -35,5 +32,5 @@ jobs:
           NPM_CONFIG_USERCONFIG: /dev/null
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn release --dry-run=${{ inputs.dry_run }}
+        run: yarn release
         if: success()

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ npm install uniswap-analytics-dev.tgz
 
 ## Releasing Events
 
-Releasing a new version of the package is performed manually using the [release](/.github/workflows/release.yaml) Github workflow.
+Releasing a new version of the package is performed automatically after pushing code to main using the [release](/.github/workflows/release.yaml) Github workflow.
 
 This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) for the release process,
 which in turn uses the [Angular commit message suggestions](https://github.com/angular/angular/blob/main/CONTRIBUTING.md) to identify the type of release.


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background

It seems like we always want to release new versions of the code to production, as changers to this repository are meant to be used immediately.

## Changes

- Release used to be a manual action, this change automates it

## Testing



#### Before merging, please ensure the following:

- [ ] All events have been approved by both product and engineering
- [ ] All events have been tested in their consuming package
- [ ] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

