### PR TITLE
feat: add a `not-found` page

### DIFF
--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -13,6 +13,7 @@ export enum PageName {
   TOKENS_PAGE = 'tokens-page',
   TOKEN_DETAILS_PAGE = 'token-details',
   VOTE_PAGE = 'vote-page',
+  NOT_FOUND = 'not-found',
 }
 
 /**

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -8,12 +8,12 @@ export enum PageName {
   NFT_DETAILS_PAGE = 'nft-details-page',
   NFT_EXPLORE_PAGE = 'nft-explore-page',
   NFT_PROFILE_PAGE = 'nft-profile-page',
+  NOT_FOUND = 'not-found',
   POOL_PAGE = 'pool-page',
   SWAP_PAGE = 'swap-page',
   TOKENS_PAGE = 'tokens-page',
   TOKEN_DETAILS_PAGE = 'token-details',
   VOTE_PAGE = 'vote-page',
-  NOT_FOUND = 'not-found',
 }
 
 /**


### PR DESCRIPTION
Recently added a new page to the interface, currently I am passing down a hardcoded `404-page` string. 