### PR TITLE
feat: add ElementNames for new tiles in about page

### DIFF
--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -42,6 +42,9 @@ export enum ModalName {
 export enum ElementName {
   ABOUT_PAGE_NFTS_CARD = 'about-page-nfts-card',
   ABOUT_PAGE_SWAP_CARD = 'about-page-swap-card',
+  ABOUT_PAGE_ANALYTICS_CARD = 'about-page-analytics-card',
+  ABOUT_PAGE_EARN_CARD = 'about-page-earn-card',
+  ABOUT_PAGE_DEV_DOCS_CARD = 'about-page-dev-docs-card',
   AUTOROUTER_VISUALIZATION_ROW = 'expandable-autorouter-visualization-row',
   BLOG_LINK = 'blog-link',
   CAREERS_LINK = 'careers-link',

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -40,11 +40,11 @@ export enum ModalName {
  * Use to identify low-level components given a TraceContext
  */
 export enum ElementName {
+  ABOUT_PAGE_ANALYTICS_CARD = 'about-page-analytics-card',
+  ABOUT_PAGE_DEV_DOCS_CARD = 'about-page-dev-docs-card',
+  ABOUT_PAGE_EARN_CARD = 'about-page-earn-card',
   ABOUT_PAGE_NFTS_CARD = 'about-page-nfts-card',
   ABOUT_PAGE_SWAP_CARD = 'about-page-swap-card',
-  ABOUT_PAGE_ANALYTICS_CARD = 'about-page-analytics-card',
-  ABOUT_PAGE_EARN_CARD = 'about-page-earn-card',
-  ABOUT_PAGE_DEV_DOCS_CARD = 'about-page-dev-docs-card',
   AUTOROUTER_VISUALIZATION_ROW = 'expandable-autorouter-visualization-row',
   BLOG_LINK = 'blog-link',
   CAREERS_LINK = 'careers-link',


### PR DESCRIPTION

## Background

implementing the designs here: https://www.figma.com/file/TBW3lYklHnv7f7Kg9ajlHb/.org-v2?node-id=2372%3A28854&t=r0v3eB6pHbfVbuQh-0


## Changes

we're adding 3 new tiles to this view. the first two already had ElementNames in this enum, so I'm adding these to keep the logging consistent.

- 

## Testing

could use some guidance here ... what's the best way to test this change against my local `interface` ?

#### Before merging, please ensure the following:

- [x] All events have been approved by both product and engineering
- [ ] All events have been tested in their consuming package
- [x] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

