### PR TITLE
revert: add back CommonJS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,29 @@
     "access": "public"
   },
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "import": {
+        "types": "./lib/esm/types/index.d.ts",
+        "default": "./lib/esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/cjs/types/index.d.ts",
+        "default": "./lib/cjs/index.js"
+      }
+    }
   },
   "files": [
-    "dist"
+    "lib"
   ],
-  "types": "./dist/types/index.d.ts",
-  "main": "./dist/index.js",
+  "types": "./lib/cjs/types/index.d.ts",
+  "main": "./lib/cjs/index.js",
   "scripts": {
-    "clean": "rm -rf ./dist",
-    "build": "yarn run clean && tsc",
-    "lint": "yarn eslint .",
+    "clean": "rm -rf ./lib",
+    "build": "yarn run clean && yarn run build:esm && yarn run build:cjs",
+    "build:esm": "tsc -p ./tsconfig.esm.json && mv lib/esm/index.js lib/esm/index.mjs",
+    "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "prepack": "yarn run build",
+    "lint": "yarn eslint .",
     "release": "semantic-release",
     "tarball": "npm pkg set version=0.0.1 && npm pack && npm pkg delete version && mv uniswap-analytics-events-0.0.1.tgz uniswap-analytics-events-dev.tgz",
     "tarball:install": "yarn run tarball && ./scripts/install-in-repo.sh"

--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -1,1 +1,3 @@
-export * from './trace'
+// .js imports required for CommonJS
+
+export * from './trace.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-export * from './primitives'
+// .js imports required for CommonJS
 
-export * from './docs'
-export * from './interface'
-export * from './nft'
-export * from './swap'
+export * from './primitives.js'
+
+export * from './docs/index.js'
+export * from './interface/index.js'
+export * from './nft/index.js'
+export * from './swap/index.js'

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -1,3 +1,5 @@
-export * from './events'
-export * from './trace'
-export * from './properties'
+// .js imports required for CommonJS
+
+export * from './events.js'
+export * from './trace.js'
+export * from './properties.js'

--- a/src/nft/index.ts
+++ b/src/nft/index.ts
@@ -1,2 +1,4 @@
-export * from './events'
-export * from './properties'
+// .js imports required for CommonJS
+
+export * from './events.js'
+export * from './properties.js'

--- a/src/swap/index.ts
+++ b/src/swap/index.ts
@@ -1,2 +1,4 @@
-export * from './events'
-export * from './properties'
+// .js imports required for CommonJS
+
+export * from './events.js'
+export * from './properties.js'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,19 +1,11 @@
 {
     "compilerOptions": {
         "strict": true,
-        "target": "ES2022",
-        "module": "esnext",
-        "moduleResolution": "node",
-        "outDir": "dist",
-        "declarationDir": "dist/types",
-        "lib": [
-            "ES2022",
-            "DOM"
-        ],
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,
         "checkJs": true,
+        "allowJs": true,
         "declaration": true,
         "declarationMap": true,
         "allowSyntheticDefaultImports": true,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "lib": [
+            "ES6",
+            "DOM"
+        ],
+        "target": "ES6",
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "outDir": "lib/cjs",
+        "declarationDir": "lib/cjs/types"
+    }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "lib": [
+            "ES2022",
+            "DOM"
+        ],
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "lib/esm",
+        "declarationDir": "lib/esm/types"
+    }
+}


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background
[Uniswap/interface](https://github.com/Uniswap/interface) unit tests rely on this support

## Changes
Reverts #27 

## Testing
- Ran test command in interface

