### PR TITLE
feat: add swap error event name

### DIFF
--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -4,6 +4,7 @@
 export enum SwapEventName {
   SWAP_AUTOROUTER_VISUALIZATION_EXPANDED = 'Swap Autorouter Visualization Expanded',
   SWAP_DETAILS_EXPANDED = 'Swap Details Expanded',
+  SWAP_ERROR = 'Swap Error',
   SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
   SWAP_PRICE_UPDATE_ACKNOWLEDGED = 'Swap Price Update Acknowledged',


### PR DESCRIPTION
## Background
We'll be logging generic swap errors on the main swap page, in order to track the effect of rolling out the widget replacement
...

## Changes
add a new event name
- 

## Testing



#### Before merging, please ensure the following:

- [x] All events have been approved by both product and engineering
- [x] All events have been tested in their consuming package
- [x] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

