### PR TITLE
fix: rename peer wallet name to agent

### DIFF
--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -80,7 +80,7 @@ export enum CustomUserProperties {
   BROWSER = 'browser',
   DARK_MODE = 'is_dark_mode',
   EXPERT_MODE = 'is_expert_mode',
-  PEER_WALLET_NAME = 'peer_wallet_name',
+  PEER_WALLET_AGENT = 'peer_wallet_agent',
   SCREEN_RESOLUTION_HEIGHT = 'screen_resolution_height',
   SCREEN_RESOLUTION_WIDTH = 'screen_resolution_width',
   USER_AGENT = 'user_agent',


### PR DESCRIPTION
this needs to be updated due to a technical detail - see https://github.com/Uniswap/interface/pull/6084

this field is not used yet, so it's safe to rename