### PR TITLE
feat: add element names for fiat on ramp buy button flow feature

### DIFF
--- a/src/interface/trace.ts
+++ b/src/interface/trace.ts
@@ -60,6 +60,8 @@ export enum InterfaceElementName {
   DOCS_LINK = 'docs-link',
   EXPLORE_BANNER = 'explore-banner',
   EXPLORE_SEARCH_INPUT = 'explore_search_input',
+  FIAT_ON_RAMP_BUY_BUTTON = 'fiat-on-ramp-buy-button',
+  FIAT_ON_RAMP_LEARN_MORE_LINK = 'fiat-on-ramp-learn-more-link',
   IMPORT_TOKEN_BUTTON = 'import-token-button',
   LANDING_PAGE_SWAP_ELEMENT = 'landing-page-swap-element',
   LEARN_MORE_LINK = 'learn-more-link',


### PR DESCRIPTION
We are adding the buy fiat flow to main swap component on interface. Add 2 additional element names for 2 additional events:
1) When 'Buy' button is clicked:
<img width="541" alt="Screen Shot 2023-03-29 at 4 22 19 PM" src="https://user-images.githubusercontent.com/41491154/228658422-8adf715f-cc2b-4483-8abb-290e7ff8e362.png">

2) When FOR is unavailable for the user, and "Learn more" link is clicked: 
<img width="335" alt="Screen Shot 2023-03-29 at 4 22 42 PM" src="https://user-images.githubusercontent.com/41491154/228658520-b86aa1c3-6249-44ce-8ead-aa1aa245c14b.png">
