### PR TITLE
feat: Add SWAP_TRANSACTION_FAILED event

### DIFF
--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -13,4 +13,5 @@ export enum SwapEventName {
   SWAP_SUBMITTED_BUTTON_CLICKED = 'Swap Submit Button Clicked',
   SWAP_TOKENS_REVERSED = 'Swap Tokens Reversed',
   SWAP_TRANSACTION_COMPLETED = 'Swap Transaction Completed',
+  SWAP_TRANSACTION_FAILED = 'Swap Transaction Failed',
 }


### PR DESCRIPTION
## Background

In the mobile wallet, we want to track events when swaps succeed and fail onchain. 

## Changes

- Adds `SWAP_TRANSACTION_FAILED` to swap events. This is meant to be used along with the existing `SWAP_TRANSACTION_COMPLETED` to track successful and failed swaps onchain. 


#### Before merging, please ensure the following:

- [x] All events have been approved by both product and engineering
- [x] All events have been tested in their consuming package
- [x] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

