### PR TITLE
feat: add swap gas estimate fail event name

### DIFF
--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -5,6 +5,7 @@ export enum SwapEventName {
   SWAP_AUTOROUTER_VISUALIZATION_EXPANDED = 'Swap Autorouter Visualization Expanded',
   SWAP_DETAILS_EXPANDED = 'Swap Details Expanded',
   SWAP_ERROR = 'Swap Error',
+  SWAP_ESTIMATE_GAS_FAILURE = 'Swap Estimate Gas Call Failed',
   SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
   SWAP_PRICE_UPDATE_ACKNOWLEDGED = 'Swap Price Update Acknowledged',

--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -5,7 +5,7 @@ export enum SwapEventName {
   SWAP_AUTOROUTER_VISUALIZATION_EXPANDED = 'Swap Autorouter Visualization Expanded',
   SWAP_DETAILS_EXPANDED = 'Swap Details Expanded',
   SWAP_ERROR = 'Swap Error',
-  SWAP_ESTIMATE_GAS_FAILURE = 'Swap Estimate Gas Call Failed',
+  SWAP_ESTIMATE_GAS_CALL_FAILED = 'Swap Estimate Gas Call Failed',
   SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
   SWAP_PRICE_UPDATE_ACKNOWLEDGED = 'Swap Price Update Acknowledged',


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background
As outlined in this [doc](https://www.notion.so/uniswaplabs/Swap-fee-on-transfer-failures-aebe8b9206cf41fe9b8b8f8b26613a43) we want to improve Swap error rates. Step 1 of this plan is to add more amplitude logging around the `estimateGas` step during a swap. A new event `SWAP_ESTIMATE_GAS_FAILURE` is to be added to allow for offline analysis of swap failures.

## Changes

- Adds`SWAP_ESTIMATE_GAS_FAILURE` to swap events. This will be used to get more detailed insights on failures relating to FOT tokens at the `estimateGas` step on the interface and mobile.

#### Before merging, please ensure the following:

- [x] All events have been approved by both product and engineering
- [x] All events have been tested in their consuming package
- [x] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

