### PR TITLE
feat: add new wallet provider used event

### DIFF
--- a/src/interface/events.ts
+++ b/src/interface/events.ts
@@ -21,6 +21,7 @@ export enum InterfaceEventName {
   UNISWAP_WALLET_APP_DOWNLOAD_OPENED = 'Uniswap Wallet App Download Opened',
   UNISWAP_WALLET_MICROSITE_OPENED = 'Uniswap Wallet Microsite Opened',
   WALLET_CONNECT_TXN_COMPLETED = 'Wallet Connect Transaction Completed',
+  WALLET_PROVIDER_USED = 'Wallet Provider Used',
   WALLET_SELECTED = 'Wallet Selected',
   WRAP_TOKEN_TXN_INVALIDATED = 'Wrap Token Transaction Invalidated',
   WRAP_TOKEN_TXN_SUBMITTED = 'Wrap Token Transaction Submitted',


### PR DESCRIPTION
## Background
As part of the multichain UX work outlined in [this doc](https://www.notion.so/uniswaplabs/MultiChain-Web-UX-127bdec19777423abf12b7b7ad98a60f) we'll need to update several locations in the interface to reference multichain instead of single chain data. Some places where we use the user's connected wallet's provider to retrieve onchain data will need to be replaced with calls to our BE or infura for xchain data which will lead to an increase in our infra costs. To prep for this we want to log the current volume for these calls to predict our anticipated price increase.
...

## Changes
- Adds the `WALLET_PROVIDER_USED` Interface event

#### Before merging, please ensure the following:

- [x] All events have been approved by both product and engineering
- [x] All events have been tested in their consuming package
- [x] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

