### PR TITLE
feat: add new event name for wallet connected

### DIFF
--- a/src/interface/events.ts
+++ b/src/interface/events.ts
@@ -21,6 +21,7 @@ export enum InterfaceEventName {
   TOKEN_SELECTOR_OPENED = 'Token Selector Opened',
   UNISWAP_WALLET_APP_DOWNLOAD_OPENED = 'Uniswap Wallet App Download Opened',
   UNISWAP_WALLET_MICROSITE_OPENED = 'Uniswap Wallet Microsite Opened',
+  WALLET_CONNECTED = 'Wallet Connected',
   WALLET_CONNECT_TXN_COMPLETED = 'Wallet Connect Transaction Completed',
   WALLET_PROVIDER_USED = 'Wallet Provider Used',
   WALLET_SELECTED = 'Wallet Selected',

--- a/src/interface/events.ts
+++ b/src/interface/events.ts
@@ -22,7 +22,6 @@ export enum InterfaceEventName {
   UNISWAP_WALLET_APP_DOWNLOAD_OPENED = 'Uniswap Wallet App Download Opened',
   UNISWAP_WALLET_MICROSITE_OPENED = 'Uniswap Wallet Microsite Opened',
   WALLET_CONNECTED = 'Wallet Connected',
-  WALLET_CONNECT_TXN_COMPLETED = 'Wallet Connect Transaction Completed',
   WALLET_PROVIDER_USED = 'Wallet Provider Used',
   WALLET_SELECTED = 'Wallet Selected',
   WRAP_TOKEN_TXN_INVALIDATED = 'Wrap Token Transaction Invalidated',


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background
currently we log `InterfaceEventName.WALLET_CONNECT_TXN_COMPLETED` whenever the user's wallet connects to our app (automatically/optimistically or manually). this is the most confusing event name anyone has ever seen. it's time to change it and migrate all the old events to the new name in amplitude.

how about `WALLET_CONNECTED`? 

...

## Changes
- add new event to replace WALLET_CONNECT_TXN_COMPLETED