### PR TITLE
feat: add wallet_version to user props

### DIFF
--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -87,4 +87,5 @@ export enum CustomUserProperties {
   USER_AGENT = 'user_agent',
   WALLET_ADDRESS = 'wallet_address',
   WALLET_TYPE = 'wallet_type',
+  WALLET_VERSION = 'wallet_version',
 }


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background
we want to log the wallet client version as a user property in the interface. e.g. if using metamask, we'll log the version of the metamask extension installed on the browser


https://docs.metamask.io/snaps/how-to/develop-a-snap/#detect-the-users-metamask-version

## Changes

- add `CustomUserProperties.WALLET_VERSION`