### PR TITLE
feat: add user property chain_id

### DIFF
--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -78,6 +78,7 @@ export enum CustomUserProperties {
   ALL_WALLET_ADDRESSES_CONNECTED = 'all_wallet_addresses_connected',
   ALL_WALLET_CHAIN_IDS = 'all_wallet_chain_ids',
   BROWSER = 'browser',
+  CHAIN_ID = 'chain_id',
   DARK_MODE = 'is_dark_mode',
   EXPERT_MODE = 'is_expert_mode',
   PEER_WALLET_AGENT = 'peer_wallet_agent',


### PR DESCRIPTION

## Background

the user chain_id property should just refer to the current chain instead of all historical chains.

currently we set a user property `ALL_WALLET_CHAIN_IDS` which records the history of connected chains. we want chain_id to match the format we use for the address - both a history and a current value. this field will be used to set the current value.

...

## Changes
- add `CustomUserProperty.CHAIN_ID`
