### PR TITLE
feat: [info] add new explore page tabs

### DIFF
--- a/src/interface/trace.ts
+++ b/src/interface/trace.ts
@@ -3,6 +3,7 @@
  */
 export enum InterfacePageName {
   ABOUT_PAGE = 'about-page',
+  EXPLORE_PAGE = 'explore-page',
   LANDING_PAGE = 'landing-page',
   NFT_COLLECTION_PAGE = 'nft-collection-page',
   NFT_DETAILS_PAGE = 'nft-details-page',
@@ -59,7 +60,10 @@ export enum InterfaceElementName {
   DISCONNECT_WALLET_BUTTON = 'disconnect-wallet-button',
   DOCS_LINK = 'docs-link',
   EXPLORE_BANNER = 'explore-banner',
+  EXPLORE_POOLS_TAB = 'explore-pools-tab',
   EXPLORE_SEARCH_INPUT = 'explore_search_input',
+  EXPLORE_TOKENS_TAB = 'explore-tokens-tab',
+  EXPLORE_TRANSACTIONS_TAB = 'explore-transactions-tab',
   FIAT_ON_RAMP_BUY_BUTTON = 'fiat-on-ramp-buy-button',
   FIAT_ON_RAMP_LEARN_MORE_LINK = 'fiat-on-ramp-learn-more-link',
   IMPORT_TOKEN_BUTTON = 'import-token-button',


### PR DESCRIPTION

## Background

Working on a new explore page for the info project - adding a couple events for the new sections

This project is working on moving all the data on info.uniswap to app.uniswap.org, with a goal to eventually deprecate the info. site. Data will be spread across the new /explore, token details, and pool detail pages. 

## Changes

- 

## Testing



#### Before merging, please ensure the following:

- [ ] All events have been approved by both product and engineering
- [ ] All events have been tested in their consuming package
- [ ] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

