### PR TITLE
feat(swap): add events for swap presets

### DIFF
--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -8,7 +8,7 @@ export enum SwapEventName {
   SWAP_ESTIMATE_GAS_CALL_FAILED = 'Swap Estimate Gas Call Failed',
   SWAP_FIRST_ACTION = 'Swap First Action',
   SWAP_FIRST_SIGNATURE_REQUESTED = 'Swap First Signature Requested',
-  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected', 
+  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
   SWAP_PRESELECT_ASSET_SELECTED = 'Swap Preselect Asset Selected',
   SWAP_PRESET_TOKEN_AMOUNT_SELECTED = 'Swap Preset Token Amount Selected',

--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -8,7 +8,7 @@ export enum SwapEventName {
   SWAP_ESTIMATE_GAS_CALL_FAILED = 'Swap Estimate Gas Call Failed',
   SWAP_FIRST_ACTION = 'Swap First Action',
   SWAP_FIRST_SIGNATURE_REQUESTED = 'Swap First Signature Requested',
-  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected', // TODO(xtine): remove after removing from universe codebase
+  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected', 
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
   SWAP_PRESELECT_ASSET_SELECTED = 'Swap Preselect Asset Selected',
   SWAP_PRESET_TOKEN_AMOUNT_SELECTED = 'Swap Preset Token Amount Selected',

--- a/src/swap/events.ts
+++ b/src/swap/events.ts
@@ -8,8 +8,10 @@ export enum SwapEventName {
   SWAP_ESTIMATE_GAS_CALL_FAILED = 'Swap Estimate Gas Call Failed',
   SWAP_FIRST_ACTION = 'Swap First Action',
   SWAP_FIRST_SIGNATURE_REQUESTED = 'Swap First Signature Requested',
-  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected',
+  SWAP_MAX_TOKEN_AMOUNT_SELECTED = 'Swap Max Token Amount Selected', // TODO(xtine): remove after removing from universe codebase
   SWAP_MODIFIED_IN_WALLET = 'Swap Modified in Wallet',
+  SWAP_PRESELECT_ASSET_SELECTED = 'Swap Preselect Asset Selected',
+  SWAP_PRESET_TOKEN_AMOUNT_SELECTED = 'Swap Preset Token Amount Selected',
   SWAP_PRICE_IMPACT_ACKNOWLEDGED = 'Swap Price Impact Acknowledged',
   SWAP_PRICE_UPDATE_ACKNOWLEDGED = 'Swap Price Update Acknowledged',
   SWAP_QUOTE_FETCH = 'Swap Quote Fetch',


### PR DESCRIPTION
## Background
- adding analytics for the swap preset features (https://www.notion.so/uniswaplabs/Swap-Presets-and-Metrics-1a5c52b2548b810c943ad729dab9599c)

## Changes
- added 2 new events for the asset preset and the percentage preset
- i will remove the max preset amount button in a follow-up PR because i confirmed its not being used in amplitude

## Testing
- after this is pushed i will use these values in universe


#### Before merging, please ensure the following:

- [ ] All events have been approved by both product and engineering
- [ ] All events have been tested in their consuming package
- [ ] This PR is titled as `feat` for any new events, or otherwise follows conventional commit standards

